### PR TITLE
Implements `Redirector::back()` fallback mechanism

### DIFF
--- a/src/Illuminate/Routing/Redirector.php
+++ b/src/Illuminate/Routing/Redirector.php
@@ -50,9 +50,7 @@ class Redirector {
 	 */
 	public function back($status = 302, $headers = array())
 	{
-		$back = $this->generator->getRequest()->headers->get('referer');
-
-		return $this->createRedirect($back, $status, $headers);
+		return $this->createRedirect($this->generator->previous(), $status, $headers);
 	}
 
 	/**

--- a/src/Illuminate/Routing/Redirector.php
+++ b/src/Illuminate/Routing/Redirector.php
@@ -46,11 +46,12 @@ class Redirector {
 	 *
 	 * @param  int    $status
 	 * @param  array  $headers
+     * @param  string|null $fallback
 	 * @return \Illuminate\Http\RedirectResponse
 	 */
-	public function back($status = 302, $headers = array())
+	public function back($status = 302, $headers = array(), $fallback = null)
 	{
-		return $this->createRedirect($this->generator->previous(), $status, $headers);
+		return $this->createRedirect($this->generator->previous($fallback), $status, $headers);
 	}
 
 	/**

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -94,14 +94,10 @@ class UrlGenerator {
 	 */
 	public function previous($fallback = null)
 	{
-        $referrer = $this->request->headers->get('referer');
+        $previousUrl = $this->request->headers->get('referer') ?: $this->getPreviousUrlFromSession();
 
-        if ($referrer) {
-            return $this->to($referrer);
-        }
-
-        if ($this->getPreviousUrlFromSession()) {
-            return $this->to($this->getPreviousUrlFromSession());
+        if ($previousUrl) {
+            return $this->to($previousUrl);
         }
 
         if (!empty($fallback)) {

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -89,11 +89,22 @@ class UrlGenerator {
 	/**
 	 * Get the URL for the previous request.
 	 *
+     * @param string|null $fallback
 	 * @return string
 	 */
-	public function previous()
+	public function previous($fallback = null)
 	{
-		return $this->to($this->request->headers->get('referer'));
+        $referrer = $this->request->headers->get('referer');
+
+        if ($referrer) {
+            return $this->to($referrer);
+        }
+
+        if (!empty($fallback)) {
+            return $this->to($fallback);
+        }
+
+		return $this->to('/');
 	}
 
 	/**

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -100,12 +100,28 @@ class UrlGenerator {
             return $this->to($referrer);
         }
 
+        if ($this->getPreviousUrlFromSession()) {
+            return $this->to($this->getPreviousUrlFromSession());
+        }
+
         if (!empty($fallback)) {
             return $this->to($fallback);
         }
 
 		return $this->to('/');
 	}
+
+    /**
+     * Get the previous URL from the session if possible.
+     *
+     * @return string|null
+     */
+    protected function getPreviousUrlFromSession()
+    {
+        $session = $this->getRequest()->session();
+
+        return $session ? $session->previousUrl() : null;
+    }
 
 	/**
 	 * Generate a absolute URL to the given path.

--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -118,9 +118,9 @@ class UrlGenerator {
      */
     protected function getPreviousUrlFromSession()
     {
-        $session = $this->getRequest()->session();
-
-        return $session ? $session->previousUrl() : null;
+        return $this->getRequest()->hasSession()
+            ? $this->getRequest()->session()->previousUrl()
+            : null;
     }
 
 	/**

--- a/src/Illuminate/Session/Middleware.php
+++ b/src/Illuminate/Session/Middleware.php
@@ -76,7 +76,7 @@ class Middleware implements HttpKernelInterface {
 		// add the session identifier cookie to the application response headers now.
 		if ($this->sessionConfigured())
 		{
-            $session->setPreviousUrl($this->getUrl($request));
+            $this->storeCurrentUrl($request, $session);
 			$this->closeSession($session);
 
 			$this->addCookieToResponse($response, $session);
@@ -171,6 +171,13 @@ class Middleware implements HttpKernelInterface {
 	{
 		return mt_rand(1, $config['lottery'][1]) <= $config['lottery'][0];
 	}
+
+    protected function storeCurrentUrl(Request $request, $session)
+    {
+        if ($request->isMethod('GET') && ! $request->isXmlHttpRequest()) {
+            $session->setPreviousUrl($this->getUrl($request));
+        }
+    }
 
 	/**
 	 * Add the session cookie to the application response.

--- a/src/Illuminate/Session/Middleware.php
+++ b/src/Illuminate/Session/Middleware.php
@@ -76,6 +76,7 @@ class Middleware implements HttpKernelInterface {
 		// add the session identifier cookie to the application response headers now.
 		if ($this->sessionConfigured())
 		{
+            $session->setPreviousUrl($this->getUrl($request));
 			$this->closeSession($session);
 
 			$this->addCookieToResponse($response, $session);

--- a/src/Illuminate/Session/Store.php
+++ b/src/Illuminate/Session/Store.php
@@ -580,6 +580,27 @@ class Store implements SessionInterface {
 		$this->put('_token', Str::random(40));
 	}
 
+    /**
+     * Get the previous URL from the session.
+     *
+     * @return string|null
+     */
+    public function previousUrl()
+    {
+        return $this->get('_previous.url');
+    }
+
+    /**
+     * Set the "previous" URL in the session.
+     *
+     * @param  string  $url
+     * @return void
+     */
+    public function setPreviousUrl($url)
+    {
+        $this->put('_previous.url', $url);
+    }
+
 	/**
 	 * Set the existence of the session on the handler if applicable.
 	 *

--- a/tests/Routing/RoutingRedirectorTest.php
+++ b/tests/Routing/RoutingRedirectorTest.php
@@ -134,6 +134,17 @@ class RoutingRedirectorTest extends BackwardCompatibleTestCase
 	}
 
 
+    public function testBackRedirectToFallbackUrl()
+	{
+        $this->headers->shouldReceive('has')->with('referer')->andReturn(false);
+        $this->headers->shouldReceive('get')->with('referer')->andReturnNull();
+        $this->url->shouldReceive('previous')->with('/fallback')->andReturn('http://foo.com/fallback');
+
+        $response = $this->redirect->back(fallback: '/fallback');
+		$this->assertEquals('http://foo.com/fallback', $response->getTargetUrl());
+	}
+
+
 	public function testAwayDoesntValidateTheUrl()
 	{
 		$response = $this->redirect->away('bar');

--- a/tests/Routing/RoutingRedirectorTest.php
+++ b/tests/Routing/RoutingRedirectorTest.php
@@ -123,17 +123,6 @@ class RoutingRedirectorTest extends BackwardCompatibleTestCase
 	}
 
 
-    public function testBackRedirectToPreviousUrlFromSession()
-	{
-        $this->headers->shouldReceive('has')->with('referer')->andReturn(false);
-        $this->headers->shouldReceive('get')->with('referer')->andReturnNull();
-        $this->url->shouldReceive('previous')->andReturn('http://foo.com/bar');
-
-        $response = $this->redirect->back();
-		$this->assertEquals('http://foo.com/bar', $response->getTargetUrl());
-	}
-
-
     public function testBackRedirectToFallbackUrl()
 	{
         $this->headers->shouldReceive('has')->with('referer')->andReturn(false);

--- a/tests/Routing/RoutingRedirectorTest.php
+++ b/tests/Routing/RoutingRedirectorTest.php
@@ -117,6 +117,7 @@ class RoutingRedirectorTest extends BackwardCompatibleTestCase
 	{
 		$this->headers->shouldReceive('has')->with('referer')->andReturn(true);
 		$this->headers->shouldReceive('get')->with('referer')->andReturn('http://foo.com/bar');
+        $this->url->shouldReceive('previous')->andReturn('http://foo.com/bar');
 		$response = $this->redirect->back();
 		$this->assertEquals('http://foo.com/bar', $response->getTargetUrl());
 	}

--- a/tests/Routing/RoutingRedirectorTest.php
+++ b/tests/Routing/RoutingRedirectorTest.php
@@ -122,6 +122,17 @@ class RoutingRedirectorTest extends BackwardCompatibleTestCase
 	}
 
 
+    public function testBackRedirectToPreviousUrlFromSession()
+	{
+        $this->headers->shouldReceive('has')->with('referer')->andReturn(false);
+        $this->headers->shouldReceive('get')->with('referer')->andReturnNull();
+        $this->url->shouldReceive('previous')->andReturn('http://foo.com/bar');
+
+        $response = $this->redirect->back();
+		$this->assertEquals('http://foo.com/bar', $response->getTargetUrl());
+	}
+
+
 	public function testAwayDoesntValidateTheUrl()
 	{
 		$response = $this->redirect->away('bar');

--- a/tests/Routing/RoutingRedirectorTest.php
+++ b/tests/Routing/RoutingRedirectorTest.php
@@ -115,8 +115,6 @@ class RoutingRedirectorTest extends BackwardCompatibleTestCase
 
 	public function testBackRedirectToHttpReferer()
 	{
-		$this->headers->shouldReceive('has')->with('referer')->andReturn(true);
-		$this->headers->shouldReceive('get')->with('referer')->andReturn('http://foo.com/bar');
         $this->url->shouldReceive('previous')->andReturn('http://foo.com/bar');
 		$response = $this->redirect->back();
 		$this->assertEquals('http://foo.com/bar', $response->getTargetUrl());
@@ -125,8 +123,6 @@ class RoutingRedirectorTest extends BackwardCompatibleTestCase
 
     public function testBackRedirectToFallbackUrl()
 	{
-        $this->headers->shouldReceive('has')->with('referer')->andReturn(false);
-        $this->headers->shouldReceive('get')->with('referer')->andReturnNull();
         $this->url->shouldReceive('previous')->with('/fallback')->andReturn('http://foo.com/fallback');
 
         $response = $this->redirect->back(fallback: '/fallback');

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -256,4 +256,19 @@ class RoutingUrlGeneratorTest extends BackwardCompatibleTestCase {
 		$this->assertEquals($url->to('/'), $url->previous());
 	}
 
+
+    public function testPreviousWithFallback(): void
+    {
+		$url = new UrlGenerator(
+			$routes = new Illuminate\Routing\RouteCollection,
+			$request = Illuminate\Http\Request::create('http://www.foo.com/')
+		);
+
+		$url->getRequest()->headers->set('referer', 'http://www.bar.com/');
+		$this->assertEquals('http://www.bar.com/', $url->previous('/some-page'));
+
+		$url->getRequest()->headers->remove('referer');
+		$this->assertEquals($url->to('/some-page'), $url->previous('/some-page'));
+	}
+
 }

--- a/tests/Routing/RoutingUrlGeneratorTest.php
+++ b/tests/Routing/RoutingUrlGeneratorTest.php
@@ -1,7 +1,9 @@
 <?php
 
 use Illuminate\Routing\UrlGenerator;
+use Illuminate\Session\Store;
 use L4\Tests\BackwardCompatibleTestCase;
+use Mockery as m;
 
 class RoutingUrlGeneratorTest extends BackwardCompatibleTestCase {
 
@@ -254,6 +256,23 @@ class RoutingUrlGeneratorTest extends BackwardCompatibleTestCase {
 
 		$url->getRequest()->headers->remove('referer');
 		$this->assertEquals($url->to('/'), $url->previous());
+	}
+
+
+    public function testPreviousUrlFromSession(): void
+    {
+        $session = m::mock(Store::class);
+        $request = Illuminate\Http\Request::create('http://www.foo.com/some');
+
+        $session->shouldReceive('previousUrl')->andReturn('http://www.foo.com/previous-page');
+        $request->setSession($session);
+
+        $url = new UrlGenerator(
+			new Illuminate\Routing\RouteCollection,
+            $request
+		);
+
+		$this->assertEquals('http://www.foo.com/previous-page', $url->previous());
 	}
 
 

--- a/tests/Session/SessionMiddlewareTest.php
+++ b/tests/Session/SessionMiddlewareTest.php
@@ -17,7 +17,7 @@ class SessionMiddlewareTest extends BackwardCompatibleTestCase
 
     public function testSessionIsProperlyStartedAndClosed()
     {
-        $request = Symfony\Component\HttpFoundation\Request::create('/', 'GET');
+        $request = Symfony\Component\HttpFoundation\Request::create('http://www.foo.com/some', 'GET');
         $response = new Symfony\Component\HttpFoundation\Response;
 
 		$middle = new Illuminate\Session\Middleware(
@@ -43,6 +43,7 @@ class SessionMiddlewareTest extends BackwardCompatibleTestCase
 		$handler->shouldReceive('gc')->once()->with(120 * 60);
 		$driver->shouldReceive('getName')->andReturn('name');
 		$driver->shouldReceive('getId')->andReturn(1);
+        $driver->shouldReceive('setPreviousUrl')->with('http://www.foo.com/some')->once();
 
 		$middleResponse = $middle->handle($request);
 

--- a/tests/Session/SessionStoreTest.php
+++ b/tests/Session/SessionStoreTest.php
@@ -291,6 +291,19 @@ class SessionStoreTest extends BackwardCompatibleTestCase
 	}
 
 
+    public function testSetPreviousUrl()
+    {
+        $session = $this->getSession();
+        $session->setPreviousUrl('https://example.com/foo/bar');
+
+        $this->assertTrue($session->has('_previous.url'));
+        $this->assertSame('https://example.com/foo/bar', $session->get('_previous.url'));
+
+        $url = $session->previousUrl();
+        $this->assertSame('https://example.com/foo/bar', $url);
+    }
+
+
 	public function getSession()
 	{
 		$reflection = new ReflectionClass(Store::class);


### PR DESCRIPTION
PR ini mencoba memasang mekanisme fallback untuk `Redirector::back()`, seperti yang disediakan oleh Laravel 5.3+, yaitu:
1. Menggunakan [header `referer`](https://github.com/illuminate/routing/blob/9d9046734fe480ff353cb84bb5a51b1a066e98a0/UrlGenerator.php#L138) (Laravel 4.x hanya mengandalkan ini saja)
2. Menggunakan [URL sebelumnya yang disimpan di session](https://github.com/illuminate/session/blob/5.3/Store.php#L708)
    - URL ini diset ketika request diproses dan membutuhkan session [middleware session](https://github.com/illuminate/session/blob/758c476b0737304b8a4b1d2cf7f42dc372e0dd5c/Middleware/StartSession.php#L134)
    - Full URL disimpan dalam session dengan key `_previous.url`
    - Hanya diterapkan untuk request dengan method `GET` dan bukan ajax
3. Menggunakan [fallback URL yang diberikan melalui parameter](https://github.com/illuminate/routing/blob/9d9046734fe480ff353cb84bb5a51b1a066e98a0/UrlGenerator.php#L145)
4. Jika semua di atas tidak tersedia, maka akan [di-redirect otomatis ke root (/)](https://github.com/illuminate/routing/blob/9d9046734fe480ff353cb84bb5a51b1a066e98a0/UrlGenerator.php#L147)