### PR TITLE
Backport `Route::redirect()` method

### DIFF
--- a/src/Illuminate/Routing/RedirectController.php
+++ b/src/Illuminate/Routing/RedirectController.php
@@ -3,7 +3,6 @@
 namespace Illuminate\Routing;
 
 use Illuminate\Http\RedirectResponse;
-use Illuminate\Http\Request;
 
 class RedirectController extends Controller
 {

--- a/src/Illuminate/Routing/RedirectController.php
+++ b/src/Illuminate/Routing/RedirectController.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Illuminate\Routing;
+
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+
+class RedirectController extends Controller
+{
+    public function action($destination, $status)
+    {
+        return new RedirectResponse($destination, $status);
+    }
+}

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -455,10 +455,15 @@ class Route {
 	 */
 	protected function replaceDefaults(array $parameters)
 	{
-		foreach ($parameters as $key => &$value)
-		{
-			$value = isset($value) ? $value : array_get($this->defaults, $key);
+		foreach ($parameters as $key => $value) {
+			$parameters[$key] = $value ?? array_get($this->defaults, $key);
 		}
+
+        foreach ($this->defaults as $key => $value) {
+            if (! isset($parameters[$key])) {
+                $parameters[$key] = $value;
+            }
+        }
 
 		return $parameters;
 	}

--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -142,7 +142,7 @@ class Route {
 		$uri = preg_replace('/\{(\w+?)\?\}/', '{$1}', $this->uri);
 
 		$this->compiled = (
-			new SymfonyRoute($uri, $optionals, $this->wheres, array(), $this->domain() ?: '')
+			new SymfonyRoute($uri, $optionals, $this->wheres, ['utf8' => true], $this->domain() ?: '')
 		)->compile();
 	}
 

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -220,6 +220,21 @@ class Router implements HttpKernelInterface, RouteFiltererInterface {
 		return $this->addRoute($verbs, $uri, $action);
 	}
 
+    /**
+     * Create a redirect from one URI to another.
+     *
+     * @param  string  $uri
+     * @param  string  $destination
+     * @param  int  $status
+     * @return \Illuminate\Routing\Route
+     */
+    public function redirect($uri, $destination, $status = 301)
+    {
+        return $this->any($uri, '\Illuminate\Routing\RedirectController@action')
+            ->defaults('destination', $destination)
+            ->defaults('status', $status);
+    }
+
 	/**
 	 * Register a new route with the given verbs.
 	 *

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -89,10 +89,9 @@ class RoutingRouteTest extends BackwardCompatibleTestCase
 		$router->get('foo/bar', fn() => 'second');
 		$this->assertEquals('second', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
 
-		// @todo fix this thest onnce you understand it
-//		$router = $this->getRouter();
-//		$router->get('foo/bar/åαф', function() { return 'hello'; });
-//		$this->assertEquals('hello', $router->dispatch(Request::create('foo/bar/%C3%A5%CE%B1%D1%84', 'GET'))->getContent());
+		$router = $this->getRouter();
+		$router->get('foo/bar/åαф', function() { return 'hello'; });
+		$this->assertEquals('hello', $router->dispatch(Request::create('foo/bar/%C3%A5%CE%B1%D1%84', 'GET'))->getContent());
 	}
 
 

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -867,6 +867,23 @@ class RoutingRouteTest extends BackwardCompatibleTestCase
 	}
 
 
+    public function testRouteParametersDefaultValue()
+    {
+        $router = $this->getRouter();
+
+        $router->get('foo/{bar?}', function ($bar = '') {
+            return $bar;
+        })->defaults('bar', 'foo');
+        $this->assertEquals('foo', $router->dispatch(Request::create('foo', 'GET'))->getContent());
+
+
+        $router->get('foo/{bar?}', function ($bar = '') {
+            return $bar;
+        })->defaults('bar', 'foo');
+        $this->assertEquals('bar', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
+    }
+
+
     public function testRouteRedirect()
     {
         $router = $this->getRouter();

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -867,6 +867,20 @@ class RoutingRouteTest extends BackwardCompatibleTestCase
 	}
 
 
+    public function testRouteRedirect()
+    {
+        $router = $this->getRouter();
+        $router->get('contact_us', function () {
+            throw new \Exception('Route should not be reachable.');
+        });
+        $router->redirect('contact_us', 'contact', 302);
+
+        $response = $router->dispatch(Request::create('contact_us', 'GET'));
+        $this->assertTrue($response->isRedirect('contact'));
+        $this->assertEquals(302, $response->getStatusCode());
+    }
+
+
 	protected function getRouter(): Router
     {
 		return new Router(new Illuminate\Events\Dispatcher);


### PR DESCRIPTION
This feature was first introduced in Laravel 5.5, see https://github.com/laravel/framework/pull/19794. This allows us to make a redirection route without making a new action/controller.