### PR TITLE
Implements single action controller

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -992,9 +992,9 @@ class Router implements HttpKernelInterface, RouteFiltererInterface {
 			// Now we can split the controller and method out of the action string so that we
 			// can call them appropriately on the class. This controller and method are in
 			// in the Class@method format and we need to explode them out then use them.
-			[$class, $method] = explode('@', $controller);
+            $classAndMethod = explode('@', $controller);
 
-			return $d->dispatch($route, $request, $class, $method);
+            return $d->dispatch($route, $request, $classAndMethod[0], $classAndMethod[1] ?? '__invoke');
 		};
 	}
 

--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -992,9 +992,13 @@ class Router implements HttpKernelInterface, RouteFiltererInterface {
 			// Now we can split the controller and method out of the action string so that we
 			// can call them appropriately on the class. This controller and method are in
 			// in the Class@method format and we need to explode them out then use them.
-            $classAndMethod = explode('@', $controller);
+            $controller = explode('@', $controller);
+            $class = $controller[0];
 
-            return $d->dispatch($route, $request, $classAndMethod[0], $classAndMethod[1] ?? '__invoke');
+            // if route action doesn't define method, then by default use `__invoke` method, thus invokable action
+            $method = $controller[1] ?? '__invoke';
+
+            return $d->dispatch($route, $request, $class, $method);
 		};
 	}
 

--- a/tests/Routing/RoutingRouteTest.php
+++ b/tests/Routing/RoutingRouteTest.php
@@ -898,6 +898,21 @@ class RoutingRouteTest extends BackwardCompatibleTestCase
     }
 
 
+    public function testDispatchingCallableActionClasses()
+    {
+        $router = $this->getRouter();
+        $router->get('foo/bar', 'ActionStub');
+
+        $this->assertEquals('hello', $router->dispatch(Request::create('foo/bar', 'GET'))->getContent());
+
+        $router->get('foo/bar2', [
+            'uses' => 'ActionStub',
+        ]);
+
+        $this->assertEquals('hello', $router->dispatch(Request::create('foo/bar2', 'GET'))->getContent());
+    }
+
+
 	protected function getRouter(): Router
     {
 		return new Router(new Illuminate\Events\Dispatcher);
@@ -993,4 +1008,12 @@ class RouteTestFilterStub {
     {
 		return 'handling!';
 	}
+}
+
+class ActionStub extends Controller
+{
+    public function __invoke(): string
+    {
+        return 'hello';
+    }
 }


### PR DESCRIPTION
## Background

Dicoding is already using [ADR pattern](https://github.com/pmjones/adr) for quite long time. This pattern maps every single route to one action controller. Currently we hard-coded the method name on the route definition, even the method name is static. Take a look below (notice the `action` method).

```php
Route::get('/users', ['uses' => 'UsersIndexAction@action']);
Route::get('/users/{id}', ['uses' => 'UsersShowAction@action']);
```

The problem with that syntax is it's quite hard to navigate to the action class. Usually we'll block the class name (e.g. `UsersIndexAction`) and trigger file search feature. Imagine if we can click-follow the action classes when we reference them using `::class` syntax, like:

```php
Route::get('/users', ['uses' => UsersIndexAction::class]);
Route::get('/users/{id}', ['uses' => UsersShowAction::class]);
```

## Solution

Laravel introduced [single action controller](https://laravel.com/docs/5.3/controllers#single-action-controllers) when version 5.3 released. The base idea is using default method for the controller, which is magic method `__invoke`. So when a developer defines a route action without method name (or by referencing the class directly), the router will dispatch the request to `__invoke` method automatically.

This PR tries to backport that feature to Laravel 4.2.

References:

- https://github.com/laravel/framework/pull/14059
- https://github.com/laravel/framework/pull/14065