### PR TITLE
[Backport] `chunkById` Database query builder method

### DIFF
--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -5,6 +5,7 @@ use Illuminate\Support\Collection;
 use Illuminate\Database\ConnectionInterface;
 use Illuminate\Database\Query\Grammars\Grammar;
 use Illuminate\Database\Query\Processors\Processor;
+use RuntimeException;
 
 class Builder {
 
@@ -2183,5 +2184,93 @@ class Builder {
 
 		throw new \BadMethodCallException("Call to undefined method {$className}::{$method}()");
 	}
+
+    /**
+     * Chunk the results of a query by comparing IDs.
+     *
+     * @param  int  $count
+     * @param  callable  $callback
+     * @param  string|null  $column
+     * @param  string|null  $alias
+     * @return bool
+     */
+    public function chunkById(int $count, callable $callback, string|null $column = null, string|null $alias = null): bool
+    {
+        $column ??= $this->defaultKeyName();
+
+        $alias ??= $column;
+
+        $lastId = null;
+
+        $page = 1;
+
+        do {
+            $clone = clone $this;
+
+            // We'll execute the query for the given page and get the results. If there are
+            // no results we can just break and return from here. When there are results
+            // we will call the callback with the current chunk of these results here.
+            $results = $clone->forPageAfterId($count, $lastId, $column)->get();
+
+            $countResults = $results->count();
+
+            if ($countResults == 0) {
+                break;
+            }
+
+            // On each chunk result set, we will pass them to the callback and then let the
+            // developer take care of everything within the callback, which allows us to
+            // keep the memory low for spinning through large result sets for working.
+            if ($callback($results, $page) === false) {
+                return false;
+            }
+
+            $lastId = data_get($results->last(), $alias);
+
+            if ($lastId === null) {
+                throw new RuntimeException("The chunkById operation was aborted because the [{$alias}] column is not present in the query result.");
+            }
+
+            unset($results);
+
+            $page++;
+        } while ($countResults == $count);
+
+        return true;
+    }
+
+    /**
+     * Constrain the query to the next "page" of results after a given ID.
+     *
+     * @param  int  $perPage
+     * @param  int|null  $lastId
+     * @param  string  $column
+     * @return $this
+     */
+    public function forPageAfterId(int $perPage = 15, int|null $lastId = 0, string $column = 'id'): Builder
+    {
+        $this->orders = $this->removeExistingOrdersFor($column);
+
+        if (! is_null($lastId)) {
+            $this->where($column, '>', $lastId);
+        }
+
+        return $this->orderBy($column, 'asc')
+            ->limit($perPage);
+    }
+
+    /**
+     * Get an array with all orders with a given column removed.
+     *
+     * @param  string  $column
+     * @return array
+     */
+    protected function removeExistingOrdersFor(string $column): array
+    {
+        return Collection::make($this->orders)
+            ->reject(function ($order) use ($column) {
+                return isset($order['column']) && $order['column'] === $column;
+            })->values()->all();
+    }
 
 }

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1584,7 +1584,7 @@ class Builder {
      * @param  string  $column
      * @return $this
      */
-    private function forPageAfterId(int $perPage = 15, int|null $lastId = 0, string $column = 'id'): Builder
+    protected function forPageAfterId(int $perPage = 15, int|null $lastId = 0, string $column = 'id'): Builder
     {
         $this->orders = $this->removeExistingOrdersFor($column);
 
@@ -1602,7 +1602,7 @@ class Builder {
      * @param  string  $column
      * @return array
      */
-    private function removeExistingOrdersFor(string $column): array
+    protected function removeExistingOrdersFor(string $column): array
     {
         return Collection::make($this->orders)
             ->reject(function ($order) use ($column) {

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1522,6 +1522,99 @@ class Builder {
 		}
 	}
 
+    /**
+     * Chunk the results of a query by comparing IDs.
+     *
+     * @param  int  $count
+     * @param  callable  $callback
+     * @param  string|null  $column
+     * @param  string|null  $alias
+     * @return bool
+     */
+    public function chunkById(int $count, callable $callback, string|null $column = null, string|null $alias = null): bool
+    {
+        $column ??= $this->defaultKeyName();
+
+        $alias ??= $column;
+
+        $lastId = null;
+
+        $page = 1;
+
+        do {
+            $clone = clone $this;
+
+            // We'll execute the query for the given page and get the results. If there are
+            // no results we can just break and return from here. When there are results
+            // we will call the callback with the current chunk of these results here.
+            $results = $clone->forPageAfterId($count, $lastId, $column)->get();
+
+            $countResults = count($results);
+
+            if ($countResults === 0) {
+                break;
+            }
+
+            // On each chunk result set, we will pass them to the callback and then let the
+            // developer take care of everything within the callback, which allows us to
+            // keep the memory low for spinning through large result sets for working.
+            if ($callback($results, $page) === false) {
+                return false;
+            }
+
+            $lastId = data_get(end($results), $alias);
+
+            if ($lastId === null) {
+                throw new RuntimeException("The chunkById operation was aborted because the [{$alias}] column is not present in the query result.");
+            }
+
+            unset($results);
+
+            $page++;
+        } while ($countResults === $count);
+
+        return true;
+    }
+
+    /**
+     * Constrain the query to the next "page" of results after a given ID.
+     *
+     * @param  int  $perPage
+     * @param  int|null  $lastId
+     * @param  string  $column
+     * @return $this
+     */
+    public function forPageAfterId(int $perPage = 15, int|null $lastId = 0, string $column = 'id'): Builder
+    {
+        $this->orders = $this->removeExistingOrdersFor($column);
+
+        if (! is_null($lastId)) {
+            $this->where($column, '>', $lastId);
+        }
+
+        return $this->orderBy($column, 'asc')
+            ->limit($perPage);
+    }
+
+    /**
+     * Get an array with all orders with a given column removed.
+     *
+     * @param  string  $column
+     * @return array
+     */
+    protected function removeExistingOrdersFor(string $column): array
+    {
+        return Collection::make($this->orders)
+            ->reject(function ($order) use ($column) {
+                return isset($order['column']) && $order['column'] === $column;
+            })->values()->all();
+    }
+
+    private function defaultKeyName(): string
+    {
+        return 'id';
+    }
+
 	/**
 	 * Get an array with the values of a given column.
 	 *
@@ -2184,98 +2277,5 @@ class Builder {
 
 		throw new \BadMethodCallException("Call to undefined method {$className}::{$method}()");
 	}
-
-    /**
-     * Chunk the results of a query by comparing IDs.
-     *
-     * @param  int  $count
-     * @param  callable  $callback
-     * @param  string|null  $column
-     * @param  string|null  $alias
-     * @return bool
-     */
-    public function chunkById(int $count, callable $callback, string|null $column = null, string|null $alias = null): bool
-    {
-        $column ??= $this->defaultKeyName();
-
-        $alias ??= $column;
-
-        $lastId = null;
-
-        $page = 1;
-
-        do {
-            $clone = clone $this;
-
-            // We'll execute the query for the given page and get the results. If there are
-            // no results we can just break and return from here. When there are results
-            // we will call the callback with the current chunk of these results here.
-            $results = $clone->forPageAfterId($count, $lastId, $column)->get();
-
-            $countResults = count($results);
-
-            if ($countResults === 0) {
-                break;
-            }
-
-            // On each chunk result set, we will pass them to the callback and then let the
-            // developer take care of everything within the callback, which allows us to
-            // keep the memory low for spinning through large result sets for working.
-            if ($callback($results, $page) === false) {
-                return false;
-            }
-
-            $lastId = data_get(end($results), $alias);
-
-            if ($lastId === null) {
-                throw new RuntimeException("The chunkById operation was aborted because the [{$alias}] column is not present in the query result.");
-            }
-
-            unset($results);
-
-            $page++;
-        } while ($countResults === $count);
-
-        return true;
-    }
-
-    /**
-     * Constrain the query to the next "page" of results after a given ID.
-     *
-     * @param  int  $perPage
-     * @param  int|null  $lastId
-     * @param  string  $column
-     * @return $this
-     */
-    public function forPageAfterId(int $perPage = 15, int|null $lastId = 0, string $column = 'id'): Builder
-    {
-        $this->orders = $this->removeExistingOrdersFor($column);
-
-        if (! is_null($lastId)) {
-            $this->where($column, '>', $lastId);
-        }
-
-        return $this->orderBy($column, 'asc')
-            ->limit($perPage);
-    }
-
-    /**
-     * Get an array with all orders with a given column removed.
-     *
-     * @param  string  $column
-     * @return array
-     */
-    protected function removeExistingOrdersFor(string $column): array
-    {
-        return Collection::make($this->orders)
-            ->reject(function ($order) use ($column) {
-                return isset($order['column']) && $order['column'] === $column;
-            })->values()->all();
-    }
-
-    private function defaultKeyName(): string
-    {
-        return 'id';
-    }
 
 }

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -1584,7 +1584,7 @@ class Builder {
      * @param  string  $column
      * @return $this
      */
-    public function forPageAfterId(int $perPage = 15, int|null $lastId = 0, string $column = 'id'): Builder
+    private function forPageAfterId(int $perPage = 15, int|null $lastId = 0, string $column = 'id'): Builder
     {
         $this->orders = $this->removeExistingOrdersFor($column);
 
@@ -1602,7 +1602,7 @@ class Builder {
      * @param  string  $column
      * @return array
      */
-    protected function removeExistingOrdersFor(string $column): array
+    private function removeExistingOrdersFor(string $column): array
     {
         return Collection::make($this->orders)
             ->reject(function ($order) use ($column) {

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2212,7 +2212,7 @@ class Builder {
             // we will call the callback with the current chunk of these results here.
             $results = $clone->forPageAfterId($count, $lastId, $column)->get();
 
-            $countResults = $results->count();
+            $countResults = count($results);
 
             if ($countResults == 0) {
                 break;
@@ -2225,7 +2225,7 @@ class Builder {
                 return false;
             }
 
-            $lastId = data_get($results->last(), $alias);
+            $lastId = data_get(end($results), $alias);
 
             if ($lastId === null) {
                 throw new RuntimeException("The chunkById operation was aborted because the [{$alias}] column is not present in the query result.");

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2273,4 +2273,9 @@ class Builder {
             })->values()->all();
     }
 
+    private function defaultKeyName(): string
+    {
+        return 'id';
+    }
+
 }

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2214,7 +2214,7 @@ class Builder {
 
             $countResults = count($results);
 
-            if ($countResults == 0) {
+            if ($countResults === 0) {
                 break;
             }
 
@@ -2234,7 +2234,7 @@ class Builder {
             unset($results);
 
             $page++;
-        } while ($countResults == $count);
+        } while ($countResults === $count);
 
         return true;
     }

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1370,9 +1370,9 @@ class DatabaseQueryBuilderTest extends BackwardCompatibleTestCase
         $builder = $this->getMockQueryBuilder();
         $builder->orders[] = ['column' => 'foobar', 'direction' => 'asc'];
 
-        $chunk1 = Collection::make([['someIdField' => 1], ['someIdField' => 2]]);
-        $chunk2 = Collection::make([['someIdField' => 10], ['someIdField' => 11]]);
-        $chunk3 = Collection::make([]);
+        $chunk1 = [['someIdField' => 1], ['someIdField' => 2]];
+        $chunk2 = [['someIdField' => 10], ['someIdField' => 11]];
+        $chunk3 = [];
         $builder->shouldReceive('forPageAfterId')->once()->with(2, 0, 'someIdField')->andReturnSelf();
         $builder->shouldReceive('forPageAfterId')->once()->with(2, 2, 'someIdField')->andReturnSelf();
         $builder->shouldReceive('forPageAfterId')->once()->with(2, 11, 'someIdField')->andReturnSelf();

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1431,6 +1431,22 @@ class DatabaseQueryBuilderTest extends BackwardCompatibleTestCase
         }, 'someIdField');
     }
 
+    public function testChunkPaginatesUsingIdWithCountZero(): void
+    {
+        $builder = $this->getMockQueryBuilder();
+        $builder->orders[] = ['column' => 'foobar', 'direction' => 'asc'];
+
+        $chunk = Collection::make([]);
+        $builder->shouldReceive('forPageAfterId')->once()->with(0, 0, 'someIdField')->andReturnSelf();
+        $builder->shouldReceive('get')->times(1)->andReturn($chunk);
+
+        $callbackAssertor = m::mock(stdClass::class);
+        $callbackAssertor->shouldReceive('doSomething')->never();
+
+        $builder->chunkById(0, function ($results) use ($callbackAssertor) {
+            $callbackAssertor->doSomething($results);
+        }, 'someIdField');
+    }
 
 	protected function getBuilder(): Builder
     {

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1363,6 +1363,29 @@ class DatabaseQueryBuilderTest extends BackwardCompatibleTestCase
 		$this->assertEquals(['foo', 'bar', 'baz'], $builder->getBindings());
 	}
 
+    public function testChunkByIdOnArrays(): void
+    {
+        $builder = $this->getMockQueryBuilder();
+        $builder->orders[] = ['column' => 'foobar', 'direction' => 'asc'];
+
+        $chunk1 = collect([['someIdField' => 1], ['someIdField' => 2]]);
+        $chunk2 = collect([['someIdField' => 10], ['someIdField' => 11]]);
+        $chunk3 = collect([]);
+        $builder->shouldReceive('forPageAfterId')->once()->with(2, 0, 'someIdField')->andReturnSelf();
+        $builder->shouldReceive('forPageAfterId')->once()->with(2, 2, 'someIdField')->andReturnSelf();
+        $builder->shouldReceive('forPageAfterId')->once()->with(2, 11, 'someIdField')->andReturnSelf();
+        $builder->shouldReceive('get')->times(3)->andReturn($chunk1, $chunk2, $chunk3);
+
+        $callbackAssertor = m::mock(stdClass::class);
+        $callbackAssertor->shouldReceive('doSomething')->once()->with($chunk1);
+        $callbackAssertor->shouldReceive('doSomething')->once()->with($chunk2);
+        $callbackAssertor->shouldReceive('doSomething')->never()->with($chunk3);
+
+        $builder->chunkById(2, function ($results) use ($callbackAssertor) {
+            $callbackAssertor->doSomething($results);
+        }, 'someIdField');
+    }
+
 
 	protected function getBuilder(): Builder
     {

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1524,7 +1524,7 @@ class DatabaseQueryBuilderTest extends BackwardCompatibleTestCase
             m::mock(ConnectionInterface::class),
             new Grammar,
             m::mock(Processor::class),
-        ])->makePartial();
+        ])->makePartial()->shouldAllowMockingProtectedMethods();
     }
 
 }

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -6,8 +6,10 @@ use Illuminate\Database\Query\Expression as Raw;
 use Illuminate\Database\Query\Grammars\Grammar;
 use Illuminate\Database\Query\Processors\Processor;
 use Illuminate\Pagination\Factory;
+use Illuminate\Support\Collection;
 use L4\Tests\BackwardCompatibleTestCase;
 use Mockery as m;
+use Mockery\MockInterface;
 
 class DatabaseQueryBuilderTest extends BackwardCompatibleTestCase
 {
@@ -1368,9 +1370,9 @@ class DatabaseQueryBuilderTest extends BackwardCompatibleTestCase
         $builder = $this->getMockQueryBuilder();
         $builder->orders[] = ['column' => 'foobar', 'direction' => 'asc'];
 
-        $chunk1 = collect([['someIdField' => 1], ['someIdField' => 2]]);
-        $chunk2 = collect([['someIdField' => 10], ['someIdField' => 11]]);
-        $chunk3 = collect([]);
+        $chunk1 = Collection::make([['someIdField' => 1], ['someIdField' => 2]]);
+        $chunk2 = Collection::make([['someIdField' => 10], ['someIdField' => 11]]);
+        $chunk3 = Collection::make([]);
         $builder->shouldReceive('forPageAfterId')->once()->with(2, 0, 'someIdField')->andReturnSelf();
         $builder->shouldReceive('forPageAfterId')->once()->with(2, 2, 'someIdField')->andReturnSelf();
         $builder->shouldReceive('forPageAfterId')->once()->with(2, 11, 'someIdField')->andReturnSelf();
@@ -1433,5 +1435,17 @@ class DatabaseQueryBuilderTest extends BackwardCompatibleTestCase
 		$processor = new Illuminate\Database\Query\Processors\MySqlProcessor;
 		return new Builder(m::mock(ConnectionInterface::class), $grammar, $processor);
 	}
+
+    /**
+     * @return MockInterface|\Illuminate\Database\Query\Builder
+     */
+    protected function getMockQueryBuilder(): MockInterface|Builder
+    {
+        return m::mock(Builder::class, [
+            m::mock(ConnectionInterface::class),
+            new Grammar,
+            m::mock(Processor::class),
+        ])->makePartial();
+    }
 
 }

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -1393,9 +1393,9 @@ class DatabaseQueryBuilderTest extends BackwardCompatibleTestCase
         $builder = $this->getMockQueryBuilder();
         $builder->orders[] = ['column' => 'foobar', 'direction' => 'asc'];
 
-        $chunk1 = Collection::make([(object) ['someIdField' => 1], (object) ['someIdField' => 2]]);
-        $chunk2 = Collection::make([(object) ['someIdField' => 10], (object) ['someIdField' => 11]]);
-        $chunk3 = Collection::make([]);
+        $chunk1 = [(object) ['someIdField' => 1], (object) ['someIdField' => 2]];
+        $chunk2 = [(object) ['someIdField' => 10], (object) ['someIdField' => 11]];
+        $chunk3 = [];
         $builder->shouldReceive('forPageAfterId')->once()->with(2, 0, 'someIdField')->andReturnSelf();
         $builder->shouldReceive('forPageAfterId')->once()->with(2, 2, 'someIdField')->andReturnSelf();
         $builder->shouldReceive('forPageAfterId')->once()->with(2, 11, 'someIdField')->andReturnSelf();
@@ -1416,8 +1416,8 @@ class DatabaseQueryBuilderTest extends BackwardCompatibleTestCase
         $builder = $this->getMockQueryBuilder();
         $builder->orders[] = ['column' => 'foobar', 'direction' => 'asc'];
 
-        $chunk1 = Collection::make([(object) ['someIdField' => 1], (object) ['someIdField' => 2]]);
-        $chunk2 = Collection::make([(object) ['someIdField' => 10]]);
+        $chunk1 = [(object) ['someIdField' => 1], (object) ['someIdField' => 2]];
+        $chunk2 = [(object) ['someIdField' => 10]];
         $builder->shouldReceive('forPageAfterId')->once()->with(2, 0, 'someIdField')->andReturnSelf();
         $builder->shouldReceive('forPageAfterId')->once()->with(2, 2, 'someIdField')->andReturnSelf();
         $builder->shouldReceive('get')->times(2)->andReturn($chunk1, $chunk2);
@@ -1436,7 +1436,7 @@ class DatabaseQueryBuilderTest extends BackwardCompatibleTestCase
         $builder = $this->getMockQueryBuilder();
         $builder->orders[] = ['column' => 'foobar', 'direction' => 'asc'];
 
-        $chunk = Collection::make([]);
+        $chunk = [];
         $builder->shouldReceive('forPageAfterId')->once()->with(0, 0, 'someIdField')->andReturnSelf();
         $builder->shouldReceive('get')->times(1)->andReturn($chunk);
 
@@ -1453,8 +1453,8 @@ class DatabaseQueryBuilderTest extends BackwardCompatibleTestCase
         $builder = $this->getMockQueryBuilder();
         $builder->orders[] = ['column' => 'foobar', 'direction' => 'asc'];
 
-        $chunk1 = Collection::make([(object) ['table_id' => 1], (object) ['table_id' => 10]]);
-        $chunk2 = Collection::make([]);
+        $chunk1 = [(object) ['table_id' => 1], (object) ['table_id' => 10]];
+        $chunk2 = [];
         $builder->shouldReceive('forPageAfterId')->once()->with(2, 0, 'table.id')->andReturnSelf();
         $builder->shouldReceive('forPageAfterId')->once()->with(2, 10, 'table.id')->andReturnSelf();
         $builder->shouldReceive('get')->times(2)->andReturn($chunk1, $chunk2);


### PR DESCRIPTION
## 🐈‍⬛ Backgrounds
Why this task should be worked on?
To bring `chunkById` database query builder method, so we can improve chunking in Laravel 4

## ✅ Todo
- [x]  First pairing with Mas Rizqy: Flow of Backporting
- [x]  Explore `chunk` and `cursor` related methods from Laravel 10
- [x]  Understand logic of the method and gather all test cases related to the methods
- [x]  Setup Dicoding L42x
    - [x]  Creating new branch
    - [x]  Backport test cases
    - [x]  Backport the codes
- [x]  Create pull request
- [ ]  Testing

## 🚏 Acceptances scenarios
- [ ]  testChunkByIdOnArrays
- [ ]  testChunkPaginatesUsingIdWithLastChunkComplete
- [ ]  testChunkPaginatesUsingIdWithLastChunkPartial
- [ ]  testChunkPaginatesUsingIdWithCountZero
- [ ]  testChunkPaginatesUsingIdWithAlias