### PR TITLE
Downgrade predis/predis to ^2.4.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "nesbot/carbon": "^2.71",
         "opis/closure": "~3.6",
         "pda/pheanstalk": "~4.0",
-        "predis/predis": "3.3",
+        "predis/predis": "^2.4.1",
         "symfony/browser-kit": "~6.4",
         "symfony/console": "~6.4",
         "symfony/css-selector": "~6.4",


### PR DESCRIPTION
## Summary
- Downgrade `predis/predis` from `3.3` to `^2.4.1` in `composer.json`.

## Why
Predis 3.x menggunakan command `HELLO` (RESP3 handshake) saat membuka koneksi. Command `HELLO` belum didukung oleh Dynomite, sehingga koneksi gagal saat aplikasi berjalan di belakang Dynomite. Menurunkan predis ke 2.4.x menghindari penggunaan `HELLO` dan menjaga kompatibilitas.

Bagian dari persiapan PHP 8.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)